### PR TITLE
Load credentials from env variable

### DIFF
--- a/hakai_api/Client.py
+++ b/hakai_api/Client.py
@@ -17,6 +17,7 @@ class Client(OAuth2Session):
     _credentials_file = os.path.expanduser("~/.hakai-api-auth")
     DEFAULT_API_ROOT = "https://hecate.hakai.org/api"
     DEFAULT_LOGIN_PAGE = "https://hecate.hakai.org/api-client-login"
+    CREDENTIALS_ENV_VAR = "HAKAI_API_CREDENTIALS"
 
     def __init__(
             self,
@@ -36,7 +37,10 @@ class Client(OAuth2Session):
         self._login_page = login_page
         self._credentials = None
 
-        if isinstance(credentials, dict):
+        env_credentials = os.getenv(self.CREDENTIALS_ENV_VAR, None)
+        if env_credentials is not None:
+            self._credentials = self._parse_credentials_string(env_credentials)
+        elif isinstance(credentials, dict):
             self._credentials = credentials
         elif isinstance(credentials, str):
             # Parse credentials from string

--- a/hakai_api/Client.py
+++ b/hakai_api/Client.py
@@ -89,8 +89,7 @@ class Client(OAuth2Session):
         """Check if the cached credentials exist and are valid."""
         if not os.path.isfile(cls._credentials_file):
             return False
-
-        with open(cls._credentials_file, "rb"):
+        with open(cls._credentials_file, "r"):
             try:
                 credentials = cls._get_credentials_from_file()
                 expires_at = int(credentials["expires_at"])
@@ -114,7 +113,7 @@ class Client(OAuth2Session):
     @classmethod
     def _get_credentials_from_file(cls) -> Dict:
         """Get user credentials from a cached file."""
-        with open(cls._credentials_file, "rb") as infile:
+        with open(cls._credentials_file, "r") as infile:
             return json.load(infile)
 
     def _get_credentials_from_web(self) -> Dict:

--- a/tests/test_Client.py
+++ b/tests/test_Client.py
@@ -92,3 +92,31 @@ def test_custom_login_page():
 
     # Check that login page is set
     assert client.login_page == 'https://example.com/login'
+
+
+def test_credentials_from_env_variable():
+    """Test that credentials can be set with the HAKAI_API_CREDENTIALS environment variable."""
+    # Remove the cached credentials file if it exists
+    Client.reset_credentials()
+
+    # Create a client object
+    now = datetime.now()
+    os.environ['HAKAI_API_CREDENTIALS'] = f"token_type=Bearer&access_token=test_access_token&expires_at={now.timestamp() + 3600}"
+    client = Client()
+
+    assert client.credentials is not None
+
+    # Check that credentials are cached and valid
+    assert client.file_credentials_are_valid()
+
+    # Check that the cached credentials can be read
+    credentials = client._get_credentials_from_file()
+    assert credentials is not None
+
+    # Check that credentials can be deleted
+    Client.reset_credentials()
+    assert not client.file_credentials_are_valid()
+    assert not os.path.exists(client._credentials_file)
+
+    # Remove the environment variable
+    del os.environ['HAKAI_API_CREDENTIALS']


### PR DESCRIPTION
This PR allows loading string credentials (as output from [https://hecate.hakai.org/api-client-login](https://hecate.hakai.org/api-client-login)) using the environment variable `HAKAI_API_CREDENTIALS`.

Resolves #6