### PR TITLE
FEAT: add user agent and test

### DIFF
--- a/src/hakai_api/Client.py
+++ b/src/hakai_api/Client.py
@@ -58,6 +58,9 @@ class Client(OAuth2Session):
 
         # Init the OAuth2Session parent class with credentials
         super(Client, self).__init__(token=self._credentials)
+        
+        # Set User-Agent header
+        self.headers.update({"User-Agent": "hakai-api-client-py"})
 
     @property
     def api_root(self) -> str:

--- a/src/hakai_api/Client.py
+++ b/src/hakai_api/Client.py
@@ -18,6 +18,7 @@ class Client(OAuth2Session):
     DEFAULT_API_ROOT = "https://hecate.hakai.org/api"
     DEFAULT_LOGIN_PAGE = "https://hecate.hakai.org/api-client-login"
     CREDENTIALS_ENV_VAR = "HAKAI_API_CREDENTIALS"
+    USER_AGENT_ENV_VAR = "HAKAI_API_USER_AGENT"
 
     def __init__(
         self,
@@ -30,6 +31,8 @@ class Client(OAuth2Session):
         Params:
             api_root: The base url of the hakai api you want to call.
                 Defaults to the production server.
+            login_page: The url of the login page to direct users to.
+                Defaults to the production login page.
             credentials (str, Dict): Credentials token retrieved from the hakai api
                 login page. If `None`, loads cached credentials or prompts for log in.
         """
@@ -60,7 +63,8 @@ class Client(OAuth2Session):
         super(Client, self).__init__(token=self._credentials)
         
         # Set User-Agent header
-        self.headers.update({"User-Agent": "hakai-api-client-py"})
+        user_agent = os.getenv(self.USER_AGENT_ENV_VAR, "hakai-api-client-py")
+        self.headers.update({"User-Agent": user_agent})
 
     @property
     def api_root(self) -> str:

--- a/tests/test_Client.py
+++ b/tests/test_Client.py
@@ -136,3 +136,24 @@ def test_credentials_from_env_variable():
 
     # Remove the environment variable
     del os.environ["HAKAI_API_CREDENTIALS"]
+
+
+def test_user_agent_header():
+    """Test that User-Agent header is correctly set."""
+    # Remove the cached credentials file if it exists
+    Client.reset_credentials()
+
+    # Create a client object
+    now = datetime.now()
+    client = Client(
+        credentials={
+            "token_type": "Bearer",
+            "access_token": "test_access_token",
+            "expires_in": 3600,
+            "expires_at": now.timestamp() + 3600,
+        },
+    )
+
+    # Check that the User-Agent header is set correctly
+    assert "User-Agent" in client.headers
+    assert client.headers["User-Agent"] == "hakai-api-client-py"

--- a/tests/test_Client.py
+++ b/tests/test_Client.py
@@ -143,7 +143,11 @@ def test_user_agent_header():
     # Remove the cached credentials file if it exists
     Client.reset_credentials()
 
-    # Create a client object
+    # Make sure environment variable is not set for this test
+    if Client.USER_AGENT_ENV_VAR in os.environ:
+        del os.environ[Client.USER_AGENT_ENV_VAR]
+
+    # Create a client object with default User-Agent
     now = datetime.now()
     client = Client(
         credentials={
@@ -154,6 +158,27 @@ def test_user_agent_header():
         },
     )
 
-    # Check that the User-Agent header is set correctly
+    # Check that the default User-Agent header is set correctly
     assert "User-Agent" in client.headers
     assert client.headers["User-Agent"] == "hakai-api-client-py"
+
+    # Test with a custom User-Agent set via environment variable
+    custom_agent = "these-are-not-the-droids-you-are-looking-for"
+    os.environ[Client.USER_AGENT_ENV_VAR] = custom_agent
+
+    # Create a new client with the environment variable set
+    client_env = Client(
+        credentials={
+            "token_type": "Bearer",
+            "access_token": "test_access_token",
+            "expires_in": 3600,
+            "expires_at": now.timestamp() + 3600,
+        },
+    )
+
+    # Check that the custom User-Agent header from env var is set correctly
+    assert "User-Agent" in client_env.headers
+    assert client_env.headers["User-Agent"] == custom_agent
+
+    # Clean up - remove the environment variable
+    del os.environ[Client.USER_AGENT_ENV_VAR]


### PR DESCRIPTION
This PR adds a user agent (`hakai-api-client-py`) to every request made using this library. 